### PR TITLE
Add additional optional flags for housekeeping_interval, disable_metr…

### DIFF
--- a/src/cadvisor-aws/start.sh
+++ b/src/cadvisor-aws/start.sh
@@ -11,6 +11,27 @@ if [ -n "$CADVISOR_PORT" ]; then
   echo "==> Found request to listen on port '${CADVISOR_PORT}', setting port option..."
 fi
 
+HOUSEKEEPING_INTERVAL_OPTION=
+if [ -n "$HOUSEKEEPING_INTERVAL" ]; then
+  HOUSEKEEPING_INTERVAL_OPTION="--housekeeping_interval=${HOUSEKEEPING_INTERVAL}"
+  echo "==> Found request to set housekeeping interval '${HOUSEKEEPING_INTERVAL}', setting interval option..."
+fi
+
+DISABLE_METRICS_OPTION=
+if [ -n "$DISABLE_METRICS" ]; then
+  DISABLE_METRICS_OPTION="--disable_metrics=${DISABLE_METRICS}"
+  echo "==> Found request to disable metrics '${DISABLE_METRICS}', setting disable metrics option..."
+fi
+
+DOCKER_ONLY_OPTION=
+if [ -n "$DOCKER_ONLY" ]; then
+  DOCKER_ONLY_OPTION="--docker_only=${DOCKER_ONLY}"
+  echo "==> Found request for docker metrics only '${DOCKER_ONLY}', setting docker only option..."
+fi
+
 exec /opt/cadvisor/bin/cadvisor \
     ${CADVISOR_LOGGING_OPTIONS} \
-    ${CADVISOR_PORT_OPTION}
+    ${CADVISOR_PORT_OPTION} \
+    ${HOUSEKEEPING_INTERVAL_OPTION} \
+    ${DISABLE_METRICS_OPTION} \
+    ${DOCKER_ONLY_OPTION}

--- a/src/cadvisor-aws/start.sh
+++ b/src/cadvisor-aws/start.sh
@@ -11,27 +11,27 @@ if [ -n "$CADVISOR_PORT" ]; then
   echo "==> Found request to listen on port '${CADVISOR_PORT}', setting port option..."
 fi
 
-HOUSEKEEPING_INTERVAL_OPTION=
-if [ -n "$HOUSEKEEPING_INTERVAL" ]; then
-  HOUSEKEEPING_INTERVAL_OPTION="--housekeeping_interval=${HOUSEKEEPING_INTERVAL}"
-  echo "==> Found request to set housekeeping interval '${HOUSEKEEPING_INTERVAL}', setting interval option..."
+CADVISOR_HOUSEKEEPING_INTERVAL_OPTION=
+if [ -n "$CADVISOR_HOUSEKEEPING_INTERVAL" ]; then
+  CADVISOR_HOUSEKEEPING_INTERVAL_OPTION="--housekeeping_interval=${CADVISOR_HOUSEKEEPING_INTERVAL}"
+  echo "==> Found request to set housekeeping interval '${CADVISOR_HOUSEKEEPING_INTERVAL}', setting interval option..."
 fi
 
-DISABLE_METRICS_OPTION=
-if [ -n "$DISABLE_METRICS" ]; then
-  DISABLE_METRICS_OPTION="--disable_metrics=${DISABLE_METRICS}"
-  echo "==> Found request to disable metrics '${DISABLE_METRICS}', setting disable metrics option..."
+CADVISOR_DISABLE_METRICS_OPTION=
+if [ -n "$CADVISOR_DISABLE_METRICS" ]; then
+  CADVISOR_DISABLE_METRICS_OPTION="--disable_metrics=${CADVISOR_DISABLE_METRICS}"
+  echo "==> Found request to disable metrics '${CADVISOR_DISABLE_METRICS}', setting disable metrics option..."
 fi
 
-DOCKER_ONLY_OPTION=
-if [ -n "$DOCKER_ONLY" ]; then
-  DOCKER_ONLY_OPTION="--docker_only=${DOCKER_ONLY}"
-  echo "==> Found request for docker metrics only '${DOCKER_ONLY}', setting docker only option..."
+CADVISOR_DOCKER_ONLY_OPTION=
+if [ -n "$CADVISOR_DOCKER_ONLY" ]; then
+  CADVISOR_DOCKER_ONLY_OPTION="--docker_only=${CADVISOR_DOCKER_ONLY}"
+  echo "==> Found request for docker metrics only '${CADVISOR_DOCKER_ONLY}', setting docker only option..."
 fi
 
 exec /opt/cadvisor/bin/cadvisor \
     ${CADVISOR_LOGGING_OPTIONS} \
     ${CADVISOR_PORT_OPTION} \
-    ${HOUSEKEEPING_INTERVAL_OPTION} \
-    ${DISABLE_METRICS_OPTION} \
-    ${DOCKER_ONLY_OPTION}
+    ${CADVISOR_HOUSEKEEPING_INTERVAL_OPTION} \
+    ${CADVISOR_DISABLE_METRICS_OPTION} \
+    ${CADVISOR_DOCKER_ONLY_OPTION}


### PR DESCRIPTION
…ics and docker_only


Based on discussions here https://github.com/google/cadvisor/issues/2523

I want to be able to set the following options for reducing cadvisor CPU usage:
```
--docker_only=true
--housekeeping_interval=30s
--disable_metrics=disk
```